### PR TITLE
Show kext error when load fails

### DIFF
--- a/load_osxfuse/fuse_kext.c
+++ b/load_osxfuse/fuse_kext.c
@@ -267,6 +267,7 @@ fuse_kext_load(void)
     } else if (ret == kOSKextReturnSystemPolicy) {
         ret = EPERM;
     } else {
+        fprintf(stderr, "kext load failed: %d\n", ret);
         ret = -1;
     }
 


### PR DESCRIPTION
Only 2 errors are handled and all other are converted to -1 so it's impossible to understand why kext loading fails when this situation occurs. Now the error is logged to stderr so programs running this can at least redirect stderr and obtain the error message for troubleshooting.